### PR TITLE
fix gevent native extension error on osx

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,7 +6,7 @@ psycopg2==2.5.2
 gunicorn==18.0
 django-storages==1.1.8
 Collectfast==0.1.13
-gevent==1.0
+gevent==1.1.2
 boto==2.23.0
 # django-pylibmc-sasl==0.2.4
 # pylibmc==1.2.2


### PR DESCRIPTION
Hello!

`pip install -r requirements.txt` fails on OSX due to incompatibilities in `gevent` module.

```
Building wheels for collected packages: gevent
 Running setup.py bdist_wheel for gevent ... error
 Complete output from command /Users/cengizIO/.virtualenvs/ocl/bin/python -u -c "import setuptools, tokenize;__file__='/private/var/folders/51/373gblw917jb0p463dp7rvh40000gn/T/pip-build-X92xGp/gevent/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /var/folders/51/373gblw917jb0p463dp7rvh40000gn/T/tmpOlHtfipip-wheel- --python-tag cp27:
 running bdist_wheel
 running build
 running build_py
 creating build
 creating build/lib.macosx-10.11-intel-2.7
 creating build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/__init__.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/_threading.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/backdoor.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/baseserver.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/coros.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/event.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/fileobject.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/greenlet.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/hub.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/local.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/lock.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/monkey.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/os.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/pool.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/pywsgi.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/queue.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/resolver_ares.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/resolver_thread.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/select.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/server.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/socket.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/ssl.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/subprocess.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/thread.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/threading.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/threadpool.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/timeout.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/util.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/win32util.py -> build/lib.macosx-10.11-intel-2.7/gevent
 copying gevent/wsgi.py -> build/lib.macosx-10.11-intel-2.7/gevent
 running build_ext
 Running '/bin/sh /private/var/folders/51/373gblw917jb0p463dp7rvh40000gn/T/pip-build-X92xGp/gevent/libev/configure > configure-output.txt' in /private/var/folders/51/373gblw917jb0p463dp7rvh40000gn/T/pip-build-X92xGp/gevent/build/temp.macosx-10.11-intel-2.7/libev
 building 'gevent.core' extension
 creating build/temp.macosx-10.11-intel-2.7/gevent
 cc -DNDEBUG -g -fwrapv -Os -Wall -Wstrict-prototypes -U__llvm__ -arch i386 -arch x86_64 -pipe -DLIBEV_EMBED=1 -DEV_COMMON= -DEV_CHECK_ENABLE=0 -DEV_CLEANUP_ENABLE=0 -DEV_EMBED_ENABLE=0 -DEV_PERIODIC_ENABLE=0 -Ibuild/temp.macosx-10.11-intel-2.7/libev -Ilibev -I/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c gevent/gevent.core.c -o build/temp.macosx-10.11-intel-2.7/gevent/gevent.core.o
 In file included from gevent/gevent.core.c:302:
 In file included from gevent/libev.h:2:
 libev/ev.c:467:48: warning: '/*' within block comment [-Wcomment]
 /*#define MIN_INTERVAL  0.00000095367431640625 /* 1/2**20, good till 2200 */
                                                ^
 libev/ev.c:935:42: error: '_Noreturn' keyword must precede function declarator
   ecb_inline void ecb_unreachable (void) ecb_noreturn;
                                          ^~~~~~~~~~~~
   _Noreturn
 libev/ev.c:738:26: note: expanded from macro 'ecb_noreturn'
   #define ecb_noreturn   _Noreturn
                          ^
 libev/ev.c:1311:31: warning: 'extern' variable has an initializer [-Wextern-initializer]
   EV_API_DECL struct ev_loop *ev_default_loop_ptr = 0; /* needs to be initialised to make it a definition despite extern */
                               ^
 libev/ev.c:1482:7: warning: unused variable 'ocur_' [-Wunused-variable]
       array_needsize (ANPENDING, pendings [pri], pendingmax [pri], w_->pending, EMPTY2);
       ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 libev/ev.c:1493:3: warning: unused variable 'ocur_' [-Wunused-variable]
   array_needsize (W, rfeeds, rfeedmax, rfeedcnt + 1, EMPTY2);
   ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 libev/ev.c:1620:7: warning: unused variable 'ocur_' [-Wunused-variable]
       array_needsize (int, fdchanges, fdchangemax, fdchangecnt, EMPTY2);
       ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 In file included from gevent/gevent.core.c:302:
 In file included from gevent/libev.h:2:
 In file included from libev/ev.c:2168:
 libev/ev_kqueue.c:50:3: warning: unused variable 'ocur_' [-Wunused-variable]
   array_needsize (struct kevent, kqueue_changes, kqueue_changemax, kqueue_changecnt, EMPTY2);
   ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 In file included from gevent/gevent.core.c:302:
 In file included from gevent/libev.h:2:
 In file included from libev/ev.c:2174:
 libev/ev_poll.c:66:7: warning: unused variable 'ocur_' [-Wunused-variable]
       array_needsize (struct pollfd, polls, pollmax, pollcnt, EMPTY2);
       ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 libev/ev.c:3332:34: warning: '&' within '|' [-Wbitwise-op-parentheses]
   fd_change (EV_A_ fd, w->events & EV__IOFDSET | EV_ANFD_REIFY);
                        ~~~~~~~~~~^~~~~~~~~~~~~ ~
 libev/ev.c:3332:34: note: place parentheses around the '&' expression to silence this warning
   fd_change (EV_A_ fd, w->events & EV__IOFDSET | EV_ANFD_REIFY);
                                  ^
                        (                      )
 libev/ev.c:3371:3: warning: unused variable 'ocur_' [-Wunused-variable]
   array_needsize (ANHE, timers, timermax, ev_active (w) + 1, EMPTY2);
   ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 libev/ev.c:4041:5: warning: unused variable 'ocur_' [-Wunused-variable]
     array_needsize (ev_idle *, idles [ABSPRI (w)], idlemax [ABSPRI (w)], active, EMPTY2);
     ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 libev/ev.c:4081:3: warning: unused variable 'ocur_' [-Wunused-variable]
   array_needsize (ev_prepare *, prepares, preparemax, preparecnt, EMPTY2);
   ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 libev/ev.c:4266:3: warning: unused variable 'ocur_' [-Wunused-variable]
   array_needsize (ev_fork *, forks, forkmax, forkcnt, EMPTY2);
   ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 libev/ev.c:4349:3: warning: unused variable 'ocur_' [-Wunused-variable]
   array_needsize (ev_async *, asyncs, asyncmax, asynccnt, EMPTY2);
   ^
 libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
       int ecb_unused ocur_ = (cur);                                     \
                      ^
 13 warnings and 1 error generated.
 error: command 'cc' failed with exit status 1

 ----------------------------------------
 Failed building wheel for gevent
 Running setup.py clean for gevent
Failed to build gevent
Installing collected packages: gevent
 Found existing installation: gevent 1.1.2
   Uninstalling gevent-1.1.2:
     Successfully uninstalled gevent-1.1.2
 Running setup.py install for gevent ... error
   Complete output from command /Users/cengizIO/.virtualenvs/ocl/bin/python -u -c "import setuptools, tokenize;__file__='/private/var/folders/51/373gblw917jb0p463dp7rvh40000gn/T/pip-build-X92xGp/gevent/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /var/folders/51/373gblw917jb0p463dp7rvh40000gn/T/pip-GVhlEa-record/install-record.txt --single-version-externally-managed --compile --install-headers /Users/cengizIO/.virtualenvs/ocl/include/site/python2.7/gevent:
   running install
   running build
   running build_py
   creating build
   creating build/lib.macosx-10.11-intel-2.7
   creating build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/__init__.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/_threading.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/backdoor.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/baseserver.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/coros.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/event.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/fileobject.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/greenlet.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/hub.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/local.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/lock.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/monkey.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/os.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/pool.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/pywsgi.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/queue.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/resolver_ares.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/resolver_thread.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/select.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/server.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/socket.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/ssl.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/subprocess.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/thread.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/threading.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/threadpool.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/timeout.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/util.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/win32util.py -> build/lib.macosx-10.11-intel-2.7/gevent
   copying gevent/wsgi.py -> build/lib.macosx-10.11-intel-2.7/gevent
   running build_ext
   Running '/bin/sh /private/var/folders/51/373gblw917jb0p463dp7rvh40000gn/T/pip-build-X92xGp/gevent/libev/configure > configure-output.txt' in /private/var/folders/51/373gblw917jb0p463dp7rvh40000gn/T/pip-build-X92xGp/gevent/build/temp.macosx-10.11-intel-2.7/libev
   building 'gevent.core' extension
   creating build/temp.macosx-10.11-intel-2.7/gevent
   cc -DNDEBUG -g -fwrapv -Os -Wall -Wstrict-prototypes -U__llvm__ -arch i386 -arch x86_64 -pipe -DLIBEV_EMBED=1 -DEV_COMMON= -DEV_CHECK_ENABLE=0 -DEV_CLEANUP_ENABLE=0 -DEV_EMBED_ENABLE=0 -DEV_PERIODIC_ENABLE=0 -Ibuild/temp.macosx-10.11-intel-2.7/libev -Ilibev -I/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c gevent/gevent.core.c -o build/temp.macosx-10.11-intel-2.7/gevent/gevent.core.o
   In file included from gevent/gevent.core.c:302:
   In file included from gevent/libev.h:2:
   libev/ev.c:467:48: warning: '/*' within block comment [-Wcomment]
   /*#define MIN_INTERVAL  0.00000095367431640625 /* 1/2**20, good till 2200 */
                                                  ^
   libev/ev.c:935:42: error: '_Noreturn' keyword must precede function declarator
     ecb_inline void ecb_unreachable (void) ecb_noreturn;
                                            ^~~~~~~~~~~~
     _Noreturn
   libev/ev.c:738:26: note: expanded from macro 'ecb_noreturn'
     #define ecb_noreturn   _Noreturn
                            ^
   libev/ev.c:1311:31: warning: 'extern' variable has an initializer [-Wextern-initializer]
     EV_API_DECL struct ev_loop *ev_default_loop_ptr = 0; /* needs to be initialised to make it a definition despite extern */
                                 ^
   libev/ev.c:1482:7: warning: unused variable 'ocur_' [-Wunused-variable]
         array_needsize (ANPENDING, pendings [pri], pendingmax [pri], w_->pending, EMPTY2);
         ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   libev/ev.c:1493:3: warning: unused variable 'ocur_' [-Wunused-variable]
     array_needsize (W, rfeeds, rfeedmax, rfeedcnt + 1, EMPTY2);
     ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   libev/ev.c:1620:7: warning: unused variable 'ocur_' [-Wunused-variable]
         array_needsize (int, fdchanges, fdchangemax, fdchangecnt, EMPTY2);
         ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   In file included from gevent/gevent.core.c:302:
   In file included from gevent/libev.h:2:
   In file included from libev/ev.c:2168:
   libev/ev_kqueue.c:50:3: warning: unused variable 'ocur_' [-Wunused-variable]
     array_needsize (struct kevent, kqueue_changes, kqueue_changemax, kqueue_changecnt, EMPTY2);
     ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   In file included from gevent/gevent.core.c:302:
   In file included from gevent/libev.h:2:
   In file included from libev/ev.c:2174:
   libev/ev_poll.c:66:7: warning: unused variable 'ocur_' [-Wunused-variable]
         array_needsize (struct pollfd, polls, pollmax, pollcnt, EMPTY2);
         ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   libev/ev.c:3332:34: warning: '&' within '|' [-Wbitwise-op-parentheses]
     fd_change (EV_A_ fd, w->events & EV__IOFDSET | EV_ANFD_REIFY);
                          ~~~~~~~~~~^~~~~~~~~~~~~ ~
   libev/ev.c:3332:34: note: place parentheses around the '&' expression to silence this warning
     fd_change (EV_A_ fd, w->events & EV__IOFDSET | EV_ANFD_REIFY);
                                    ^
                          (                      )
   libev/ev.c:3371:3: warning: unused variable 'ocur_' [-Wunused-variable]
     array_needsize (ANHE, timers, timermax, ev_active (w) + 1, EMPTY2);
     ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   libev/ev.c:4041:5: warning: unused variable 'ocur_' [-Wunused-variable]
       array_needsize (ev_idle *, idles [ABSPRI (w)], idlemax [ABSPRI (w)], active, EMPTY2);
       ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   libev/ev.c:4081:3: warning: unused variable 'ocur_' [-Wunused-variable]
     array_needsize (ev_prepare *, prepares, preparemax, preparecnt, EMPTY2);
     ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   libev/ev.c:4266:3: warning: unused variable 'ocur_' [-Wunused-variable]
     array_needsize (ev_fork *, forks, forkmax, forkcnt, EMPTY2);
     ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   libev/ev.c:4349:3: warning: unused variable 'ocur_' [-Wunused-variable]
     array_needsize (ev_async *, asyncs, asyncmax, asynccnt, EMPTY2);
     ^
   libev/ev.c:1444:22: note: expanded from macro 'array_needsize'
         int ecb_unused ocur_ = (cur);                                     \
                        ^
   13 warnings and 1 error generated.
   error: command 'cc' failed with exit status 1

   ----------------------------------------
 Rolling back uninstall of gevent
```

Upgrading `gevent` to the latest version fixed the problem.

Thanks!