### PR TITLE
Implemented new concepts overview page

### DIFF
--- a/ocl_web/templates/concepts/concept_base.html
+++ b/ocl_web/templates/concepts/concept_base.html
@@ -82,6 +82,7 @@
                                         <a id="edit-concept" href="{{ concept_edit_url }}" class="text-muted small"
                                            title="Edit Concept"><span class="glyphicon glyphicon-pencil"></span></a>
                                     {% endif_can_change concept %}
+                                    <a id="concept-version-permalink" href="{{ concept.version_url }}" class="text-muted small" title="Concept Version Permalink"><span class="glyphicon glyphicon-link"></span></a>
                                 {% endif %}
                             </div>
                             <p>
@@ -92,9 +93,9 @@
                                 <em>Class:</em> {{ concept.concept_class }},
                                 <em>Datatype:</em> {{ concept.datatype }}<br/>
                                 <span class="text-muted small">
-							<span class="glyphicon glyphicon-calendar"></span> Created on {{ concept.created_on|smart_date }}
-							&nbsp;&nbsp;
-							<span class="glyphicon glyphicon-calendar"></span> Last updated {{ concept.updated_on|smart_date }}
+							<span class="glyphicon glyphicon-calendar"></span> Created on {{ concept.created_on|smart_date }} by {{ concept.version_created_by }}
+							&nbsp;&nbsp;<span class="glyphicon glyphicon-calendar"></span> Last updated {{ concept.updated_on|smart_date }}
+                            {% if concept.external_id %}&nbsp;&nbsp;<span class="glyphicon glyphicon-circle-arrow-right"></span> External ID: {{ concept.external_id }}{% endif %}
 						</span>
                             </p>
                         </div> <!-- /resource-header-label -->

--- a/ocl_web/templates/concepts/concept_details.html
+++ b/ocl_web/templates/concepts/concept_details.html
@@ -8,33 +8,8 @@
 <div class="container" style="margin-top: 20px;">
 	<div class="row">
 
-		<!-- Concept Details -->
-		<div class="col-md-4">
-			<div class="panel panel-default">
-				<div class="panel-heading"><h3 class="panel-title">Concept Details</h3></div>
-				<div class="panel-body" style="overflow-x:scroll;">
-					{% field_label 'ID' concept.id vertical="true" small="true" %}
-					{% field_label 'Default Display Name' concept.display_name vertical="true" small="true" %}
-					{% field_label 'Display Name Locale' concept.display_locale vertical="true" small="true" %}
-					{% field_label 'Concept Class' concept.concept_class vertical="true" small="true" %}
-					{% field_label 'Datatype' concept.datatype vertical="true" small="true" %}
-					{% field_label 'Retired' concept.retired vertical="true" small="true" %}
-					<span class="concept-version-url">{% field_label 'Concept Version URL' concept.version_url vertical="true" truncate=False small="true" %}</span>
-					{% if concept.external_id %}
-					<hr />
-					{% field_label 'External ID' concept.external_id vertical="true" small="true" %}
-					{% endif %}
-					<hr />
-					{% field_label 'Updated by' concept.version_created_by vertical="true" small="true" %}
-					{% field_label 'Updated on' concept.version_created_on|smart_datetime vertical="true" small="true" %}
-					{% field_label 'Created on' concept.created_on|smart_datetime vertical="true" small="true" %}
-				</div>
-			</div>
-		</div>
-
-
-		<!-- Concept Names, Descriptions, and Extras -->
-		<div class="col-md-8">
+		<!-- Concept Names, Descriptions, and Custom Attributes -->
+		<div class="col-md-6">
 			<div class="panel panel-default">
 
 				<!-- Concept names -->
@@ -115,6 +90,106 @@
 					{% endif %}
 				</div>
 
+			</div>
+		</div>
+
+
+		<!-- Concept Names, Descriptions, and Custom Attributes -->
+		<div class="col-md-6">
+			<div class="panel panel-default">
+
+				<!-- Mappings -->
+				<div class="panel-heading"><h3 class="panel-title">Mappings</h3></div>
+				<div class="panel-body" style="overflow-x:scroll;">
+				{% if concept.has_direct_mappings %}
+					<table class="table table-striped">
+						<thead>
+							<tr>
+								<th width="1">&nbsp;</th>
+								<th>Relationship</th>
+								<th>Source</th>
+								<th>Code</th>
+								<th>Name</th>
+							</tr>
+						</thead>
+						<tbody>
+						{% for mapping in concept.mappings %}
+							{% if mapping.is_direct_mapping %}
+								{% if mapping.to_source_owner_type == 'Organization' %}
+									{% url 'org-home' org=mapping.to_source_owner as to_concept_owner_url %}
+									{% url 'source-home' org=mapping.to_source_owner source=mapping.to_source_name as to_concept_source_url %}
+									{% if mapping.is_internal_mapping %}
+										{% url 'concept-home' org=mapping.to_source_owner source=mapping.to_source_name concept=mapping.to_concept_code as to_concept_url %}
+									{% endif %}
+								{% else %}
+									{% url 'users:detail' mapping.to_source_owner as to_concept_owner_url %}
+									{% url 'source-home' user=mapping.to_source_owner source=mapping.to_source_name as to_concept_source_url %}
+									{% if mapping.is_internal_mapping %}
+										{% url 'concept-home' user=mapping.to_source_owner source=mapping.to_source_name concept=mapping.to_concept_code as to_concept_url %}
+									{% endif %}
+								{% endif %}
+
+							<tr>
+								<td>{% if mapping.is_external_mapping %}<span class="glyphicon glyphicon-circle-arrow-right" title="External Mapping"></span>{% else %}&nbsp;{% endif %}</td>
+								<td>{{ mapping.map_type }}</td>
+								<td><a href="{{ to_concept_owner_url }}">{{ mapping.to_source_owner }}</a> / <a href="{{ to_concept_source_url }}">{{ mapping.to_source_name }}</a></td>
+								<td>{% if mapping.is_internal_mapping %}<a href="{{ to_concept_url }}">{{ mapping.to_concept_code }}</a>{% else %}{{ mapping.to_concept_code }}{% endif %}</td>
+								<td>{{ mapping.to_concept_name|default:"-" }}</td>
+							</tr>
+							{% endif %}
+						{% endfor %}
+						</tbody>
+					</table>
+				{% else %}
+					<h3><small>No direct mappings</small></h3>
+				{% endif %}
+				</div>
+
+				<!-- Inverse Mappings -->
+				<div class="panel-heading"><h3 class="panel-title">Inverse Mappings</h3></div>
+				<div class="panel-body" style="overflow-x:scroll;">
+				{% if concept.has_inverse_mappings %}
+					<table class="table table-striped">
+						<thead>
+							<tr>
+								<th width="1">&nbsp;</th>
+								<th>Relationship</th>
+								<th>Source</th>
+								<th>Code</th>
+								<th>Name</th>
+							</tr>
+						</thead>
+						<tbody>
+						{% for mapping in concept.mappings %}
+							{% if mapping.is_inverse_mapping %}
+								{% if mapping.to_source_owner_type == 'Organization' %}
+									{% url 'org-home' org=mapping.from_source_owner as from_concept_owner_url %}
+									{% url 'source-home' org=mapping.from_source_owner source=mapping.from_source_name as from_concept_source_url %}
+									{% url 'concept-home' org=mapping.from_source_owner source=mapping.from_source_name concept=mapping.from_concept_code as from_concept_url %}
+								{% else %}
+									{% url 'users:detail' mapping.from_source_owner as from_concept_owner_url %}
+									{% url 'source-home' user=mapping.from_source_owner source=mapping.from_source_name as from_concept_source_url %}
+									{% url 'concept-home' user=mapping.from_source_owner source=mapping.from_source_name concept=mapping.from_concept_code as from_concept_url %}
+								{% endif %}
+
+							<tr>
+								<td>{% if mapping.is_external_mapping %}<span class="glyphicon glyphicon-circle-arrow-right" title="External Mapping"></span>{% else %}&nbsp;{% endif %}</td>
+								<td>{{ mapping.map_type }}</td>
+								<td><a href="{{ from_concept_owner_url }}">{{ mapping.from_source_owner }}</a> / <a href="{{ from_concept_source_url }}">{{ mapping.from_source_name }}</a></td>
+								<td><a href="{{ from_concept_url }}">{{ mapping.from_concept_code }}</a></td>
+								<td>{{ mapping.from_concept_name|default:"-" }}</td>
+							</tr>
+							{% endif %}
+						{% endfor %}
+						</tbody>
+					</table>
+				{% else %}
+					<h3><small>No inverse mappings</small></h3>
+				{% endif %}
+				</div>
+
+
+				<div class="panel-footer small"><em>* Only mappings defined in this source are displayed here</em></div>
 			</div>
 		</div>
 

--- a/ocl_web/templates/includes/footer.html
+++ b/ocl_web/templates/includes/footer.html
@@ -9,7 +9,7 @@
             <!--li><a href="{% url 'contact' %}">Contact</a></li-->
         </ul>
         <ul class="site-footer-links pull-left" style="padding-left:0;">
-            <li>&copy; 2016 Open Concept Lab</li>
+            <li>&copy; 2017 Open Concept Lab</li>
             <li><a href="{% url 'license' %}">License</a></li>
             <!--li><a href="{% url 'terms' %}">Terms</a></li-->
             <!--li><a href="{% url 'privacy' %}">Privacy</a></li-->

--- a/ocl_web/templates/includes/nav.html
+++ b/ocl_web/templates/includes/nav.html
@@ -22,7 +22,7 @@
           <input name="q" id="global_search" type="text" class="form-control" placeholder="Search OCL" value="{{ search_query }}" />
           <span class="input-group-btn" style="width:30px;"><button class="btn btn-default" type="submit"><span class="glyphicon glyphicon-search"></span></button></span>
         </div><!-- /.form-group -->
-        <div class="checkbox navbar-btn"><label for="exact_match_global_search" class="navbar-link" style="font-weight:300;"><input name="exact_match" type="checkbox" tooltip="Exact match" {% if request.GET.exact_match %}checked="checked"{% endif %} id="exact_match_global_search" style="cursor:pointer;" />&nbsp;<span class="small">{% trans "Exact match" %}</span></label></div>
+        <div class="checkbox navbar-btn"><label for="exact_match_global_search" class="navbar-link" style="font-weight:300;"><input name="exact_match" type="checkbox" title="Exact match" {% if request.GET.exact_match %}checked="checked"{% endif %} id="exact_match_global_search" style="cursor:pointer;" />&nbsp;<span class="small">{% trans "Exact match" %}</span></label></div>
         {% if request.GET.type %}<input type="hidden" name="type" value="{{ request.GET.type }}" />{% endif %}
         {% if request.GET.debug %}<input type="hidden" name="debug" value="{{ request.GET.debug }}" />{% endif %}
       </form><!-- /.navbar-form -->


### PR DESCRIPTION
Concept details pane integrated into header/breadcrumb, names/desc/extras moved to left, and added new mappings/inverse mappings panes. Mappings pane needs review, e.g. what is the right ordering of map types? Should Q-AND-A and CONCEPT-SET be pulled out separately to make them easier to navigate? Should mappings that are internal to the source be presented differently?