### PR TITLE
Example .env contents in README are misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ Web client interface for Open Concept Lab terminology services API.
 Docker
 
 Create the .env file at the root of the project with the following variables:
+```
 OCL_API_TOKEN=65d5a5012b608cb60d10d535e003e2b36e1d3201
 OCL_ANON_API_TOKEN=65d5a5012b608cb60d10d535e003e2b36e1d3201
 OCL_API_NETWORK=ocl_default
+```
 
 The token needs to be taken from OCL API at http://localhost:8000/admin/authtoken/token/
 The network used by OCL API is called projectname_default, where projectname is the directory from which you started OCL API.


### PR DESCRIPTION
Put example `.env` file contents into block so they are properly displayed as separate lines in README.