### PR TITLE
Add -y option to apt-get install curl in Dockerfile-dependencies

### DIFF
--- a/Dockerfile-dependencies
+++ b/Dockerfile-dependencies
@@ -11,9 +11,9 @@ RUN set -ex && \
       openjdk-8-jre-headless \
       ca-certificates-java -y
 
-RUN apt-get install curl
+RUN apt-get -y install curl
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash
-RUN apt-get -y install nodejs 
+RUN apt-get -y install nodejs
 
 RUN apt-get install -y -qq ruby-dev
 RUN apt-get install -y rubygems


### PR DESCRIPTION
docker-compose up fails when running dependency 4, apt-get install curl, because a Y/n confirmation is needed.  
Added -y option to confirm the install.