### PR TITLE
Upgrading psycopg2 to fix Error: could not determine PostgreSQL version from '11.5'

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -2,7 +2,7 @@
 #	production that isn't in development.
 -r base.txt
 
-psycopg2==2.5.2
+psycopg2==2.8.3
 gunicorn==18.0
 django-storages==1.1.8
 Collectfast==0.1.13


### PR DESCRIPTION
https://ci.openmrs.org/browse/OCL-OWD-55/log