### PR TITLE
Global Search | Sort filters Fixes

### DIFF
--- a/ocl_web/templates/ocl_search/search.html
+++ b/ocl_web/templates/ocl_search/search.html
@@ -102,7 +102,7 @@
                                     <ul class="dropdown-menu" role="menu">
                                         {% for sort_option_def in search_sort_option_defs %}
                                             <li {% if search_sort == sort_option_def.value %}class="active"{% endif %}>
-                                                <a href="{% url 'search' %}?{{ other_resource_search_params }}&amp;sort={{ sort_option_def.value|urlencode }}&amp;type={{search_type_name}}s"><span
+                                                <a href="{% url 'search' %}?{{ other_resource_search_params }}&amp;sort={{ sort_option_def.value|urlencode }}&amp;type={{search_type}}"><span
                                                         class="glyphicon {{ sort_option_def.icon }}"></span>&nbsp;{{ sort_option_def.display }}
                                                 </a></li>
                                         {% endfor %}

--- a/ocl_web/templates/ocl_search/search.html
+++ b/ocl_web/templates/ocl_search/search.html
@@ -20,27 +20,27 @@
 
                     <!-- Search Categories -->
                     <div class="hidden-xs list-group global-resource-selector">
-                        <a href="{% url 'search' %}?type=concepts{{ other_resource_search_params }}"
+                        <a href="{% url 'search' %}?type=concepts{{ other_resource_search_params }}&amp;sort={{ search_sort|urlencode }}"
                            class="list-group-item {% if search_type == 'concepts' %}active{% endif %}" title="Concepts"><span
                                 class="glyphicon glyphicon-tag"></span><span class="">&nbsp;&nbsp;Concepts </span><span
                                 class="badge">{{ resource_count.concepts|intcomma }}</span></a>
-                        <a href="{% url 'search' %}?type=mappings{{ other_resource_search_params }}"
+                        <a href="{% url 'search' %}?type=mappings{{ other_resource_search_params }}&amp;sort={{ search_sort|urlencode }}"
                            class="list-group-item {% if search_type == 'mappings' %}active{% endif %}" title="Mappings"><span
                                 class="glyphicon glyphicon-link"></span><span class="">&nbsp;&nbsp;Mappings </span><span
                                 class="badge">{{ resource_count.mappings|intcomma }}</span></a>
-                        <a href="{% url 'search' %}?type=sources{{ other_resource_search_params }}"
+                        <a href="{% url 'search' %}?type=sources{{ other_resource_search_params }}&amp;sort={{ search_sort|urlencode }}"
                            class="list-group-item {% if search_type == 'sources' %}active{% endif %}"
                            title="Sources"><span class="glyphicon glyphicon-th-list"></span><span class="">&nbsp;&nbsp;Sources </span><span
                                 class="badge">{{ resource_count.sources|intcomma }}</span></a>
-                        <a href="{% url 'search' %}?type=collections{{ other_resource_search_params }}"
+                        <a href="{% url 'search' %}?type=collections{{ other_resource_search_params }}&amp;sort={{ search_sort|urlencode }}"
                            class="list-group-item {% if search_type == 'collections' %}active{% endif %}"
                            title="Collections"><span class="glyphicon glyphicon-tags"></span><span class="">&nbsp;&nbsp;Collections </span><span
                                 class="badge">{{ resource_count.collections|intcomma }}</span></a>
-                        <a href="{% url 'search' %}?type=orgs{{ other_resource_search_params }}"
+                        <a href="{% url 'search' %}?type=orgs{{ other_resource_search_params }}&amp;sort={{ search_sort|urlencode }}"
                            class="list-group-item {% if search_type == 'orgs' %}active{% endif %}"
                            title="Organizations"><span class="glyphicon glyphicon-home"></span><span class="">&nbsp;&nbsp;Organizations </span><span
                                 class="badge">{{ resource_count.orgs|intcomma }}</span></a>
-                        <a href="{% url 'search' %}?type=users{{ other_resource_search_params }}"
+                        <a href="{% url 'search' %}?type=users{{ other_resource_search_params }}&amp;sort={{ search_sort|urlencode }}"
                            class="list-group-item {% if search_type == 'users' %}active{% endif %}" title="Users"><span
                                 class="glyphicon glyphicon-user"></span><span class="">&nbsp;&nbsp;Users </span><span
                                 class="badge">{{ resource_count.users|intcomma }}</span></a>
@@ -102,7 +102,7 @@
                                     <ul class="dropdown-menu" role="menu">
                                         {% for sort_option_def in search_sort_option_defs %}
                                             <li {% if search_sort == sort_option_def.value %}class="active"{% endif %}>
-                                                <a href="{% url 'search' %}?{{ other_resource_search_params }}&amp;sort={{ sort_option_def.value|urlencode }}"><span
+                                                <a href="{% url 'search' %}?{{ other_resource_search_params }}&amp;sort={{ sort_option_def.value|urlencode }}&amp;type={{search_type_name}}s"><span
                                                         class="glyphicon {{ sort_option_def.icon }}"></span>&nbsp;{{ sort_option_def.display }}
                                                 </a></li>
                                         {% endfor %}


### PR DESCRIPTION
Right now there is no way to sort on anything by anything except concepts.

Fixes following in Global search view:
* Apply any sort filters on concepts and navigate to mappings (or any other resource) sort filter is lost
* Select any resource type other than concepts, apply any sort filter, it will apply filter and redirect to concepts results.

